### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.0 (2021-12-18)
+
+* `#[evt(derive(..))]` on enum adds derives on every variant. ([#6], [#7])
+* `#[evt(module = "module1")]` generates structs inside `mod module1`. ([#5], [#7])
+* `#[evt(implement_marker_traits(MarkerTrait1))]` on enum generates `impl MarkerTrait1` for all generated structs. ([#7])
+
+[#5]: https://github.com/azriel91/enum_variant_type/issues/5
+[#6]: https://github.com/azriel91/enum_variant_type/issues/6
+[#7]: https://github.com/azriel91/enum_variant_type/pulls/7
+
 ## 0.2.1 (2021-04-24)
 
 * `no-std` support by default. ([#2], [#3])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum_variant_type"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Azriel Hoh <mail@azriel.im>"]
 edition = "2018"
 description = "Generates types for each enum variant and conversion trait impls."

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a poor-man's implementation of <https://github.com/rust-lang/rfcs/pull/2
 
 ```toml
 [dependencies]
-enum_variant_type = "0.2.0"
+enum_variant_type = "0.3.0"
 ```
 
 ## Examples

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! enum_variant_type = "0.2.0"
+//! enum_variant_type = "0.3.0"
 //! ```
 //!
 //! # Examples


### PR DESCRIPTION
Includes: 

* `#[evt(derive(..))]` on enum adds derives on every variant. ([#6], [#7])
* `#[evt(module = "module1")]` generates structs inside `mod module1`. ([#5], [#7])
* `#[evt(implement_marker_traits(MarkerTrait1))]` on enum generates `impl MarkerTrait1` for all generated structs. ([#7])

[#5]: https://github.com/azriel91/enum_variant_type/issues/5
[#6]: https://github.com/azriel91/enum_variant_type/issues/6
[#7]: https://github.com/azriel91/enum_variant_type/pulls/7