### PR TITLE
Module generation import fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ fn enum_variant_type_impl(ast: DeriveInput) -> proc_macro2::TokenStream {
     if let Some(module_to_wrap_in) = wrap_in_module {
         quote! {
             #vis mod #module_to_wrap_in {
-                use super::#enum_name;
+                use super::*;
 
                 #struct_declarations
             }
@@ -523,7 +523,7 @@ mod tests {
         let actual_tokens = enum_variant_type_impl(ast);
         let expected_tokens = quote! {
             pub mod example {
-                use super::MyEnum;
+                use super::*;
 
                 pub struct A;
 


### PR DESCRIPTION
Hey, made a little mistake in #7. If generating variants into a module with `#[evt(module = "module1")]` then the module **only** *imported* the enum declaration not any types, traits or proc derive macros. This means output wouldn't compile if the structure had non prelude types in fields or used non prelude marker traits or proc derive macros. This PR fixes that by importing everything from the parent scope with `use super::*;`